### PR TITLE
fix ArweaveSigner import

### DIFF
--- a/src/signing/chains/index.ts
+++ b/src/signing/chains/index.ts
@@ -1,6 +1,6 @@
-export * from "./ArweaveSigner";
+import ArweaveSigner from './ArweaveSigner';
 export * from "./ethereum";
 export * from "./PolygonSigner";
 export * from "./SolanaSigner";
 
-
+export { ArweaveSigner };

--- a/src/signing/constants.ts
+++ b/src/signing/constants.ts
@@ -1,7 +1,7 @@
 import { Signer } from "./Signer";
 import Curve25519 from './keys/curve25519';
 import Ethereum from "./chains/ethereum";
-import ArweaveSigner from './chains';
+import { ArweaveSigner } from './chains';
 
 interface IndexToType {
   [key: number]: {

--- a/src/signing/index.ts
+++ b/src/signing/index.ts
@@ -1,8 +1,4 @@
-import ArweaveSigner from "./chains";
-
 export * from "./Signer";
 export * from "./constants";
 export * from "./keys";
 export * from "./chains";
-
-export { ArweaveSigner };


### PR DESCRIPTION
Currently on master:

```
ERROR: src/signing/index.ts:1:8 - error TS1192: Module '"/home/Repositories/arbundles/src/signing/chains/index"' has no default export.

1 import ArweaveSigner from "./chains";
         ~~~~~~~~~~~~~

  src/signing/chains/index.ts:1:1
    1 export * from "./ArweaveSigner";
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    'export *' does not re-export a default.
```