### PR TITLE
Add check for equality of items in meta to real items

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,9 +34,9 @@
     "spaced-comment": "error",
     "arrow-spacing": "error",
     "@typescript-eslint/naming-convention": [
-      "error",
-      { "selector": "class", "format": ["StrictPascalCase"] },
-      { "selector": "interface", "format": ["StrictPascalCase"] },
+      "warning",
+      { "selector": "class", "format": ["PascalCase"] },
+      { "selector": "interface", "format": ["PascalCase","camelCase"] },
       {
         "selector": "classProperty",
         "format": ["camelCase"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,20 +34,18 @@
     "spaced-comment": "error",
     "arrow-spacing": "error",
     "@typescript-eslint/naming-convention": [
-      "warning",
-      { "selector": "class", "format": ["PascalCase"] },
-      { "selector": "interface", "format": ["PascalCase","camelCase"] },
-      {
-        "selector": "classProperty",
-        "format": ["camelCase"],
-        "leadingUnderscore": "allow"
-      },
-      { "selector": "objectLiteralProperty", "format": null },
-      {
-        "selector": "default",
-        "format": ["strictCamelCase"],
-        "leadingUnderscore": "allow"
-      } //this must be the last rule
+      "error", 
+      {"selector": "enum", "format":["PascalCase"]},
+      {"selector": "enumMember", "format":["UPPER_CASE"]},
+      {"selector": "class","format":["PascalCase"]},
+      {"selector": "interface","format":["PascalCase"]},
+      {"selector": "typeAlias","format":["PascalCase"]},
+      {"selector": "classProperty","format":["camelCase"], "leadingUnderscore":"allow"},
+      {"selector": "objectLiteralProperty", "format":null},
+      {"selector": "typeLike", "format":["PascalCase", "camelCase"]},
+      {"selector": "variable", "modifiers": [ "const"], "format":["UPPER_CASE","camelCase"] , "filter": {"regex":"^_.*","match":false}},
+      {"selector": "variable", "modifiers": ["exported", "const"], "format":["UPPER_CASE", "camelCase"]},
+      {"selector": "default","format": ["strictCamelCase"], "leadingUnderscore": "allow" } //this must be the last rule
     ]
   }
 }

--- a/src/Bundle.ts
+++ b/src/Bundle.ts
@@ -53,6 +53,9 @@ export default class Bundle implements BundleInterface {
   public getIds(): string[] {
     const ids = [];
     for (let i = HEADER_START; i < HEADER_START + 64 * this.length; i += 64) {
+      if (this.binary.subarray(i + 32, i + 64).length === 0) {
+        throw new Error("Invalid bundle, id specified in headers isn't existing in bundle.")
+      }
       ids.push(base64url.encode(this.binary.subarray(i + 32, i + 64)));
     }
 
@@ -180,7 +183,9 @@ export default class Bundle implements BundleInterface {
     for (let i = HEADER_START; i < HEADER_START + 64 * this.length; i += 64) {
       const _offset = byteArrayToLong(this.binary.subarray(i, i + 32));
       const _id = this.binary.subarray(i + 32, i + 64);
-
+       if (_id.length === 0) {
+        throw new Error("Invalid bundle, id specified in headers isn't existing in bundle.")
+      }
       const dataItemStart = bundleStart + offset;
       const bytes = this.binary.subarray(
         dataItemStart,

--- a/src/Bundle.ts
+++ b/src/Bundle.ts
@@ -55,7 +55,7 @@ export default class Bundle implements BundleInterface {
     for (let i = HEADER_START; i < HEADER_START + 64 * this.length; i += 64) {
       const bundleId = this.binary.subarray(i + 32, i + 64)
       if (bundleId.length === 0) {
-        throw new Error("Invalid bundle, id specified in headers isn't existing in bundle.")
+        throw new Error("Invalid bundle, id specified in headers doesn't exist")
       }
       ids.push(base64url.encode(bundleId));
     }
@@ -185,7 +185,7 @@ export default class Bundle implements BundleInterface {
       const _offset = byteArrayToLong(this.binary.subarray(i, i + 32));
       const _id = this.binary.subarray(i + 32, i + 64);
        if (_id.length === 0) {
-        throw new Error("Invalid bundle, id specified in headers isn't existing in bundle.")
+        throw new Error("Invalid bundle, id specified in headers doesn't exist")
       }
       const dataItemStart = bundleStart + offset;
       const bytes = this.binary.subarray(

--- a/src/Bundle.ts
+++ b/src/Bundle.ts
@@ -53,7 +53,7 @@ export default class Bundle implements BundleInterface {
   public getIds(): string[] {
     const ids = [];
     for (let i = HEADER_START; i < HEADER_START + 64 * this.length; i += 64) {
-      let bundledID=this.binary.subarray(i + 32, i + 64)
+      let bundledID = this.binary.subarray(i + 32, i + 64)
       if (bundledID.length === 0) {
         throw new Error("Invalid bundle, id specified in headers isn't existing in bundle.")
       }

--- a/src/Bundle.ts
+++ b/src/Bundle.ts
@@ -53,11 +53,11 @@ export default class Bundle implements BundleInterface {
   public getIds(): string[] {
     const ids = [];
     for (let i = HEADER_START; i < HEADER_START + 64 * this.length; i += 64) {
-      let bundledID = this.binary.subarray(i + 32, i + 64)
-      if (bundledID.length === 0) {
+      const bundleId = this.binary.subarray(i + 32, i + 64)
+      if (bundleId.length === 0) {
         throw new Error("Invalid bundle, id specified in headers isn't existing in bundle.")
       }
-      ids.push(base64url.encode(bundledID));
+      ids.push(base64url.encode(bundleId));
     }
 
     return ids;

--- a/src/Bundle.ts
+++ b/src/Bundle.ts
@@ -53,10 +53,11 @@ export default class Bundle implements BundleInterface {
   public getIds(): string[] {
     const ids = [];
     for (let i = HEADER_START; i < HEADER_START + 64 * this.length; i += 64) {
-      if (this.binary.subarray(i + 32, i + 64).length === 0) {
+      let bundledID=this.binary.subarray(i + 32, i + 64)
+      if (bundledID.length === 0) {
         throw new Error("Invalid bundle, id specified in headers isn't existing in bundle.")
       }
-      ids.push(base64url.encode(this.binary.subarray(i + 32, i + 64)));
+      ids.push(base64url.encode(bundledID));
     }
 
     return ids;


### PR DESCRIPTION
Helps to prevent "Fake-items loop", on which parser, when eating malicious data, just does big useless loop that eats resources and nothing more.