### PR TITLE
feat: :sparkles: DataItem setSignature utility method for server side signing

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,20 +34,18 @@
     "spaced-comment": "error",
     "arrow-spacing": "error",
     "@typescript-eslint/naming-convention": [
-      "error",
-      { "selector": "class", "format": ["StrictPascalCase"] },
-      { "selector": "interface", "format": ["StrictPascalCase"] },
-      {
-        "selector": "classProperty",
-        "format": ["camelCase"],
-        "leadingUnderscore": "allow"
-      },
-      { "selector": "objectLiteralProperty", "format": null },
-      {
-        "selector": "default",
-        "format": ["strictCamelCase"],
-        "leadingUnderscore": "allow"
-      } //this must be the last rule
+      "error", 
+      {"selector": "enum", "format":["PascalCase"]},
+      {"selector": "enumMember", "format":["UPPER_CASE"]},
+      {"selector": "class","format":["PascalCase"]},
+      {"selector": "interface","format":["PascalCase"]},
+      {"selector": "typeAlias","format":["PascalCase"]},
+      {"selector": "classProperty","format":["camelCase"], "leadingUnderscore":"allow"},
+      {"selector": "objectLiteralProperty", "format":null},
+      {"selector": "typeLike", "format":["PascalCase", "camelCase"]},
+      {"selector": "variable", "modifiers": [ "const"], "format":["UPPER_CASE","camelCase"] , "filter": {"regex":"^_.*","match":false}},
+      {"selector": "variable", "modifiers": ["exported", "const"], "format":["UPPER_CASE", "camelCase"]},
+      {"selector": "default","format": ["strictCamelCase"], "leadingUnderscore": "allow" } //this must be the last rule
     ]
   }
 }

--- a/src/DataItem.ts
+++ b/src/DataItem.ts
@@ -198,7 +198,7 @@ export default class DataItem implements BundleItem {
     return this.rawId;
   }
 
-  public async setSignature(signature: Buffer) {
+  public async setSignature(signature: Buffer): Promise<void> {
     this.binary.set(signature, 2)
     this._id = Buffer.from(await Arweave.crypto.hash(signature));
   }

--- a/src/DataItem.ts
+++ b/src/DataItem.ts
@@ -9,6 +9,7 @@ import { getSignatureData } from "./ar-data-base";
 import axios, { AxiosResponse } from "axios";
 import { SIG_CONFIG, SignatureConfig } from "./constants";
 import * as crypto from "crypto";
+import Arweave from "arweave";
 
 export const MIN_BINARY_SIZE = 80;
 
@@ -195,6 +196,11 @@ export default class DataItem implements BundleItem {
   public async sign(signer: Signer): Promise<Buffer> {
     this._id = await sign(this, signer);
     return this.rawId;
+  }
+
+  public async setSignature(signature: Buffer) {
+    this.binary.set(signature, 2)
+    this._id = Buffer.from(await Arweave.crypto.hash(signature));
   }
 
   public isSigned(): boolean {


### PR DESCRIPTION
Adds the setSignature utility method to DataItem to allow for sign method equivalent server side signing.