### PR TITLE
feat: :ambulance: Mirror AVSC en/decoding logic, expand test cases, add MAX_TAG_BYTES

### DIFF
--- a/src/DataItem.ts
+++ b/src/DataItem.ts
@@ -12,6 +12,7 @@ import { deserializeTags } from "./tags";
 import { createHash } from "crypto";
 
 export const MIN_BINARY_SIZE = 80;
+export const MAX_TAG_BYTES = 4096;
 
 export class DataItem implements BundleItem {
   private readonly binary: Buffer;
@@ -215,7 +216,7 @@ export class DataItem implements BundleItem {
     const numberOfTagBytesArray = buffer.subarray(tagsStart + 8, tagsStart + 16);
     const numberOfTagBytes = byteArrayToLong(numberOfTagBytesArray);
 
-    if (numberOfTagBytes > 4096) return false;
+    if (numberOfTagBytes > MAX_TAG_BYTES) return false;
 
     if (numberOfTags > 0) {
       try {

--- a/src/__tests__/tags.spec.ts
+++ b/src/__tests__/tags.spec.ts
@@ -19,9 +19,9 @@ const tagsParser = Type.forSchema({
 
 function serializeTagsAVSC(
   tags: { name: string; value: string; }[],
-): Uint8Array {
+): Buffer {
   if (tags!.length == 0) {
-    return new Uint8Array(0);
+    return Buffer.from([0]);
   }
 
   let tagsBuffer;
@@ -33,12 +33,12 @@ function serializeTagsAVSC(
     );
   }
 
-  return Uint8Array.from(tagsBuffer);
+  return tagsBuffer
 }
 
 export function generateRandomTags(
-  tagsCount = randomInt(1, 100),
-  maxChars = 1000,
+  tagsCount = randomInt(1, 25),
+  maxChars = 100,
 ) {
   return new Array(tagsCount).fill(undefined).map(() => {
     return {
@@ -48,45 +48,104 @@ export function generateRandomTags(
   });
 }
 
-const sTags = [{ name: "ThisIsAShortName", value: "ThisIsAShortValue" }];
-const lTags = [
-  {
-    name: "ThisIsALongNameAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-    value:
-      "ThisIsALongValueAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-  },
-];
-const sTagsEnc = Buffer.from([
-  2, 32, 84, 104, 105, 115, 73, 115, 65, 83, 104, 111, 114, 116, 78, 97, 109,
-  101, 34, 84, 104, 105, 115, 73, 115, 65, 83, 104, 111, 114, 116, 86, 97, 108,
-  117, 101, 0,
-]);
-const lTagsEnc = Buffer.from([
-  2, 128, 1, 84, 104, 105, 115, 73, 115, 65, 76, 111, 110, 103, 78, 97, 109,
-  101, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65,
-  65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65,
-  65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 156, 1, 84, 104, 105, 115, 73,
-  115, 65, 76, 111, 110, 103, 86, 97, 108, 117, 101, 65, 65, 65, 65, 65, 65, 65,
-  65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65,
-  65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65,
-  65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 0,
-]);
+
+
+ 
+const rustTags = {
+  dec: [{name: "Hello", value: "Bundlr!"}, {name: "This is a ", value: "Test"}],
+  enc: Buffer.from([4, 10, 72, 101, 108, 108, 111, 14, 66, 117, 110, 100, 108, 114, 33, 20, 84, 104, 105, 115, 32, 105, 115, 32, 97, 32, 8, 84, 101, 115, 116, 0])
+  }
+
+const warpTags = {
+  dec: [
+    {
+      name: "YnVuZGxlci10ZXN0cw",
+      value: "dHJ1ZQ",
+    },
+    {
+      name: "ZFJUQUJSb1VNSmRXTUFtVGlQUlZ6T3hLc3Vya29HeEJlaFF6UlB5d2dITw",
+      value: "enBJVFFUUWpzSGRtSFlVTGpCamZOZllpcHNaaUNRUENycEFSQUxaenJheQ",
+    },
+    {
+      name: "WFRvbkZlaFltYmRWb21RUUtMWFZGc2tqak1wZkxFZGhlcnpoclRJT05vTg",
+      value: "YkNtcXpZS254RUtFQXVKa0VGSUdaVGl3c29xdWdsWEZYeVVNUUhXQVNNdQ",
+    },
+    {
+      name: "T25QVnp6RENsY3RIVUVFd3VhZ0xmYlVNc0pZTmV0ZkpXeFVLRXdpV2Z6Sg",
+      value: "R3BocXp4bU5xekNQUFF3eUtVY2pXeXhUSldpTkhwTWtvT3JVbGdlQ2FRbA",
+    },
+    {
+      name: "SWZzUmVyTXJ4VmtBTnpjUGpoZG1SSkZwTWlFTEJXS1NBWVNHQ2p1TGREaA",
+      value: "b1NHbWtNRlRjeg",
+    },
+  ],
+  // strange, equivalent encoding.
+  weirdEnc: Buffer.from([9, 140, 7, 36, 89, 110, 86, 117, 90, 71, 120, 108, 99, 105, 49, 48, 90, 88, 78, 48, 99, 119, 12, 100, 72, 74, 49, 90, 81, 116, 90, 70, 74, 85, 81, 85, 74, 83, 98, 49, 86, 78, 83, 109, 82, 88, 84, 85, 70, 116, 86, 71, 108, 81, 85, 108, 90, 54, 84, 51, 104, 76, 99, 51, 86, 121, 97, 50, 57, 72, 101, 69, 74, 108, 97, 70, 70, 54, 85, 108, 66, 53, 100, 50, 100, 73, 84, 119, 116, 101, 110, 66, 74, 86, 70, 70, 85, 85, 87, 112, 122, 83, 71, 82, 116, 83, 70, 108, 86, 84, 71, 112, 67, 97, 109, 90, 79, 90, 108, 108, 112, 99, 72, 78, 97, 97, 85, 78, 82, 85, 69, 78, 121, 99, 69, 70, 83, 81, 85, 120, 97, 101, 110, 74, 104, 101, 81, 116, 87, 70, 82, 118, 98, 107, 90, 108, 97, 70, 108, 116, 89, 109, 82, 87, 98, 50, 49, 82, 85, 85, 116, 77, 87, 70, 90, 71, 99, 50, 116, 113, 97, 107, 49, 119, 90, 107, 120, 70, 90, 71, 104, 108, 99, 110, 112, 111, 99, 108, 82, 74, 84, 48, 53, 118, 84, 103, 116, 89, 107, 78, 116, 99, 88, 112, 90, 83, 50, 53, 52, 82, 85, 116, 70, 81, 88, 86, 75, 97, 48, 86, 71, 83, 85, 100, 97, 86, 71, 108, 51, 99, 50, 57, 120, 100, 87, 100, 115, 87, 69, 90, 89, 101, 86, 86, 78, 85, 85, 104, 88, 81, 86, 78, 78, 100, 81, 116, 84, 50, 53, 81, 86, 110, 112, 54, 82, 69, 78, 115, 89, 51, 82, 73, 86, 85, 86, 70, 100, 51, 86, 104, 90, 48, 120, 109, 89, 108, 86, 78, 99, 48, 112, 90, 84, 109, 86, 48, 90, 107, 112, 88, 101, 70, 86, 76, 82, 88, 100, 112, 86, 50, 90, 54, 83, 103, 116, 82, 51, 66, 111, 99, 88, 112, 52, 98, 85, 53, 120, 101, 107, 78, 81, 85, 70, 70, 51, 101, 85, 116, 86, 89, 50, 112, 88, 101, 88, 104, 85, 83, 108, 100, 112, 84, 107, 104, 119, 84, 87, 116, 118, 84, 51, 74, 86, 98, 71, 100, 108, 81, 50, 70, 82, 98, 65, 116, 83, 87, 90, 122, 85, 109, 86, 121, 84, 88, 74, 52, 86, 109, 116, 66, 84, 110, 112, 106, 85, 71, 112, 111, 90, 71, 49, 83, 83, 107, 90, 119, 84, 87, 108, 70, 84, 69, 74, 88, 83, 49, 78, 66, 87, 86, 78, 72, 81, 50, 112, 49, 84, 71, 82, 69, 97, 65, 28, 98, 49, 78, 72, 98, 87, 116, 78, 82, 108, 82, 106, 101, 103, 0]),
+  enc:      Buffer.from([10, 36, 89, 110, 86, 117, 90, 71, 120, 108, 99, 105, 49, 48, 90, 88, 78, 48, 99, 119, 12, 100, 72, 74, 49, 90, 81, 116, 90, 70, 74, 85, 81, 85, 74, 83, 98, 49, 86, 78, 83, 109, 82, 88, 84, 85, 70, 116, 86, 71, 108, 81, 85, 108, 90, 54, 84, 51, 104, 76, 99, 51, 86, 121, 97, 50, 57, 72, 101, 69, 74, 108, 97, 70, 70, 54, 85, 108, 66, 53, 100, 50, 100, 73, 84, 119, 116, 101, 110, 66, 74, 86, 70, 70, 85, 85, 87, 112, 122, 83, 71, 82, 116, 83, 70, 108, 86, 84, 71, 112, 67, 97, 109, 90, 79, 90, 108, 108, 112, 99, 72, 78, 97, 97, 85, 78, 82, 85, 69, 78, 121, 99, 69, 70, 83, 81, 85, 120, 97, 101, 110, 74, 104, 101, 81, 116, 87, 70, 82, 118, 98, 107, 90, 108, 97, 70, 108, 116, 89, 109, 82, 87, 98, 50, 49, 82, 85, 85, 116, 77, 87, 70, 90, 71, 99, 50, 116, 113, 97, 107, 49, 119, 90, 107, 120, 70, 90, 71, 104, 108, 99, 110, 112, 111, 99, 108, 82, 74, 84, 48, 53, 118, 84, 103, 116, 89, 107, 78, 116, 99, 88, 112, 90, 83, 50, 53, 52, 82, 85, 116, 70, 81, 88, 86, 75, 97, 48, 86, 71, 83, 85, 100, 97, 86, 71, 108, 51, 99, 50, 57, 120, 100, 87, 100, 115, 87, 69, 90, 89, 101, 86, 86, 78, 85, 85, 104, 88, 81, 86, 78, 78, 100, 81, 116, 84, 50, 53, 81, 86, 110, 112, 54, 82, 69, 78, 115, 89, 51, 82, 73, 86, 85, 86, 70, 100, 51, 86, 104, 90, 48, 120, 109, 89, 108, 86, 78, 99, 48, 112, 90, 84, 109, 86, 48, 90, 107, 112, 88, 101, 70, 86, 76, 82, 88, 100, 112, 86, 50, 90, 54, 83, 103, 116, 82, 51, 66, 111, 99, 88, 112, 52, 98, 85, 53, 120, 101, 107, 78, 81, 85, 70, 70, 51, 101, 85, 116, 86, 89, 50, 112, 88, 101, 88, 104, 85, 83, 108, 100, 112, 84, 107, 104, 119, 84, 87, 116, 118, 84, 51, 74, 86, 98, 71, 100, 108, 81, 50, 70, 82, 98, 65, 116, 83, 87, 90, 122, 85, 109, 86, 121, 84, 88, 74, 52, 86, 109, 116, 66, 84, 110, 112, 106, 85, 71, 112, 111, 90, 71, 49, 83, 83, 107, 90, 119, 84, 87, 108, 70, 84, 69, 74, 88, 83, 49, 78, 66, 87, 86, 78, 72, 81, 50, 112, 49, 84, 71, 82, 69, 97, 65, 28, 98, 49, 78, 72, 98, 87, 116, 78, 82, 108, 82, 106, 101, 103, 0])
+}
+const shortTags = {
+  dec: [{ name: "ThisIsAShortName", value: "ThisIsAShortValue" }],
+  enc: Buffer.from([
+    2, 32, 84, 104, 105, 115, 73, 115, 65, 83, 104, 111, 114, 116, 78, 97, 109,
+    101, 34, 84, 104, 105, 115, 73, 115, 65, 83, 104, 111, 114, 116, 86, 97, 108,
+    117, 101, 0,
+  ])
+}
+
+const longTags = {
+  dec: [
+    {
+      name: "ThisIsALongNameAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      value:
+        "ThisIsALongValueAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    },
+  ],
+  enc: Buffer.from([
+    2, 128, 1, 84, 104, 105, 115, 73, 115, 65, 76, 111, 110, 103, 78, 97, 109,
+    101, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65,
+    65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65,
+    65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 156, 1, 84, 104, 105, 115, 73,
+    115, 65, 76, 111, 110, 103, 86, 97, 108, 117, 101, 65, 65, 65, 65, 65, 65, 65,
+    65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65,
+    65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65,
+    65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 0,
+  ])
+}
+
+
+const testTags = {rustTags, warpTags,shortTags, longTags }
 
 describe("Tag tests", function () {
-  it("should encode the sample tags correctly", function () {
-    const parserEncodeS = serializeTags(sTags);
-    expect(parserEncodeS).toEqual(sTagsEnc);
-    const parserEncodeL = serializeTags(lTags);
-    expect(parserEncodeL).toEqual(lTagsEnc);
+  describe("should encode the sample tags correctly", function () {
+    test.each(Object.keys(testTags))("%s", (key) => {
+      const {enc, dec} = testTags[key]
+      const sec1 = serializeTags(dec)
+      expect(sec1).toEqual(enc)
+      const sec2 = serializeTagsAVSC(dec)
+      expect(sec2).toEqual(enc)
+    })
+
+
   });
-  it("should decode the sample tags correctly", function () {
-    expect(deserializeTags(sTagsEnc)).toEqual(sTags);
-    expect(deserializeTags(lTagsEnc)).toEqual(lTags);
+  describe("should decode the sample tags correctly", function () {
+    test.each(Object.keys(testTags))("%s", (key) => {
+      const {enc, dec} = testTags[key]
+      expect(deserializeTags(enc)).toEqual(dec)
+      expect(tagsParser.fromBuffer(enc)).toEqual(dec)
+    })
   });
+  it("Should correctly decode the different encoding of warpTags", function () {
+    expect(deserializeTags(warpTags.weirdEnc)).toEqual(warpTags.dec)
+    expect(tagsParser.fromBuffer(warpTags.weirdEnc)).toEqual(warpTags.dec)
+  })
   it("should correctly encode/decode random tags", function () {
     const randomTags = generateRandomTags();
     let serializedTags = serializeTags(randomTags);
-    expect(serializedTags).toEqual(Buffer.from(serializeTagsAVSC(randomTags)));
-    expect(deserializeTags(serializedTags)).toEqual(randomTags);
+    const deTags = deserializeTags(serializedTags)
+    expect(deTags).toEqual(randomTags);
+    const avscTags = Buffer.from(serializeTagsAVSC(randomTags))
+    const deAvscTags = tagsParser.fromBuffer(serializedTags)
+    expect(serializedTags).toStrictEqual(avscTags);
+    expect(deAvscTags).toEqual(randomTags)
   });
 });

--- a/src/__tests__/tags.spec.ts
+++ b/src/__tests__/tags.spec.ts
@@ -37,7 +37,7 @@ function serializeTagsAVSC(
 }
 
 export function generateRandomTags(
-  tagsCount = randomInt(1, 25),
+  tagsCount = randomInt(1, 20),
   maxChars = 100,
 ) {
   return new Array(tagsCount).fill(undefined).map(() => {

--- a/src/file/FileDataItem.ts
+++ b/src/file/FileDataItem.ts
@@ -3,7 +3,7 @@ import { createReadStream, promises, read as FSRead, write as FSWrite } from "fs
 import type { PathLike } from "fs";
 import { byteArrayToLong } from "../utils";
 import type { BundleItem } from "../BundleItem";
-import { deepHash } from "../index";
+import { deepHash, MAX_TAG_BYTES } from "../index";
 import { getCryptoDriver, stringToBuffer } from "$/utils";
 import type { Signer } from "../signing/index";
 import { indexToType } from "../signing/index";
@@ -65,7 +65,7 @@ export class FileDataItem implements BundleItem {
 
     const numberOfTags = await read(handle.fd, Buffer.allocUnsafe(8), 0, 8, tagsStart).then((r) => byteArrayToLong(r.buffer));
     const numberOfTagsBytes = await read(handle.fd, Buffer.allocUnsafe(8), 0, 8, tagsStart + 8).then((r) => byteArrayToLong(r.buffer));
-    if (numberOfTagsBytes > 4096) {
+    if (numberOfTagsBytes > MAX_TAG_BYTES) {
       await handle.close();
       return false;
     }
@@ -197,7 +197,7 @@ export class FileDataItem implements BundleItem {
     }
     const numberOfTagsBytesBuffer = await read(handle.fd, Buffer.allocUnsafe(8), 0, 8, tagsStart + 8).then((r) => r.buffer);
     const numberOfTagsBytes = byteArrayToLong(numberOfTagsBytesBuffer);
-    if (numberOfTagsBytes > 4096) {
+    if (numberOfTagsBytes > MAX_TAG_BYTES) {
       await handle.close();
       throw new Error("Tags too large");
     }

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -26,7 +26,8 @@ export class AVSCTap {
       for (i = 0; i < n; i++) {
         // for this use case, assume tags/strings.
         const tag = tags[i];
-        if (!tag.name || !tag.value) throw new Error(`Invalid tag format for ${tag}, expected {name:string, value: string}`);
+        if (tag.name === undefined || tag.value === undefined)
+          throw new Error(`Invalid tag format for ${tag}, expected {name:string, value: string}`);
         this.writeString(tag.name);
         this.writeString(tag.value);
         // this.itemsType._write(tap, val[i]);

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -38,7 +38,7 @@ export class AVSCTap {
 
   public toBuffer(): Buffer {
     const buffer = Buffer.alloc(this.pos);
-    if (this.pos > this.buf.length) throw new Error(`Too many tag bytes`);
+    if (this.pos > this.buf.length) throw new Error(`Too many tag bytes (${this.pos} > ${this.buf.length})`);
     this.buf.copy(buffer, 0, 0, this.pos);
     return buffer;
   }

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -26,7 +26,7 @@ export class AVSCTap {
       for (i = 0; i < n; i++) {
         // for this use case, assume tags/strings.
         const tag = tags[i];
-        if (tag.name === undefined || tag.value === undefined)
+        if (tag?.name === undefined || tag?.value === undefined)
           throw new Error(`Invalid tag format for ${tag}, expected {name:string, value: string}`);
         this.writeString(tag.name);
         this.writeString(tag.value);

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -1,63 +1,136 @@
-// taken from AVSC - Tap.prototype.writeLong
-function encodeLong(n: number): Buffer {
-  let buf = Buffer.alloc(0);
-  let f, m;
-  let offset = 0;
+import { MAX_TAG_BYTES } from "../index";
 
-  if (n >= -1073741824 && n < 1073741824) {
-    // Won't overflow, we can use integer arithmetic.
-    m = n >= 0 ? n << 1 : (~n << 1) | 1;
-    do {
-      buf = Buffer.concat([buf, Buffer.alloc(1)]);
-      buf[offset] = m & 0x7f;
-      m >>= 7;
-    } while (m && (buf[offset++] |= 0x80));
-  } else {
-    // We have to use slower floating arithmetic.
-    f = n >= 0 ? n * 2 : -n * 2 - 1;
-    do {
-      buf = Buffer.concat([buf, Buffer.alloc(1)]);
-      buf[offset] = f & 0x7f;
-      f /= 128;
-    } while (f >= 1 && (buf[offset++] |= 0x80));
-  }
-  return buf;
+export interface Tag {
+  name: string;
+  value: string;
 }
 
-export function serializeTags(tags: { name: string; value: string }[]): Buffer {
-  let byt = Buffer.from("");
-  if (!tags) return byt;
-  // number of tags
-  byt = Buffer.concat([byt, encodeLong(tags.length)]);
-  for (const tag of tags) {
-    if (tag?.name === undefined || tag?.value === undefined) throw new Error(`Invalid tag format for ${tag}, expected {name:string, value: string}`);
-    const name = Buffer.from(tag.name);
-    const value = Buffer.from(tag.value);
-    // encode the length of the field using variable integer encoding
-    byt = Buffer.concat([byt, encodeLong(name.byteLength)]);
-    // then the value
-    byt = Buffer.concat([byt, name]);
-    byt = Buffer.concat([byt, encodeLong(value.byteLength)]);
-    byt = Buffer.concat([byt, value]);
-  }
-  // 0 terminator
-  byt = Buffer.concat([byt, encodeLong(0)]);
-  return byt;
-}
+export class AVSCTap {
+  protected buf: Buffer;
+  protected pos: number;
 
-export function deserializeTags(bTags: Buffer): { name: string; value: string }[] {
-  if (bTags.length === 0) return [];
-  const tags = [];
-  let offset = 0;
-  let length = 0;
-  // Taken from AVSC - Tap.prototype.readLong
-  const decodeLong = (buf: Buffer): number => {
+  constructor(buf = Buffer.alloc(MAX_TAG_BYTES), pos = 0) {
+    this.buf = buf;
+    this.pos = pos;
+  }
+
+  public writeTags(tags: Tag[]): void {
+    if (!Array.isArray(tags)) {
+      throw new Error("input must be array");
+    }
+
+    const n = tags.length;
+    let i;
+    if (n) {
+      this.writeLong(n);
+      for (i = 0; i < n; i++) {
+        // for this use case, assume tags/strings.
+        const tag = tags[i];
+        if (!tag.name || !tag.value) throw new Error(`Invalid tag format for ${tag}, expected {name:string, value: string}`);
+        this.writeString(tag.name);
+        this.writeString(tag.value);
+        // this.itemsType._write(tap, val[i]);
+      }
+    }
+    this.writeLong(0);
+  }
+
+  public toBuffer(): Buffer {
+    const buffer = Buffer.alloc(this.pos);
+    if (this.pos > this.buf.length) throw new Error(`Too many tag bytes`);
+    this.buf.copy(buffer, 0, 0, this.pos);
+    return buffer;
+  }
+
+  protected writeLong(n: number): void {
+    const buf = this.buf;
+    let f, m;
+
+    if (n >= -1073741824 && n < 1073741824) {
+      // Won't overflow, we can use integer arithmetic.
+      m = n >= 0 ? n << 1 : (~n << 1) | 1;
+      do {
+        buf[this.pos] = m & 0x7f;
+        m >>= 7;
+      } while (m && (buf[this.pos++] |= 0x80));
+    } else {
+      // We have to use slower floating arithmetic.
+      f = n >= 0 ? n * 2 : -n * 2 - 1;
+      do {
+        buf[this.pos] = f & 0x7f;
+        f /= 128;
+      } while (f >= 1 && (buf[this.pos++] |= 0x80));
+    }
+    this.pos++;
+    this.buf = buf;
+  }
+
+  // for some reason using setters/getters with ++ doesn't work right.
+  // set pos(newPos: number) {
+  //   const d = newPos + 1 - this.buf.length;
+  //   if (d > 0) this.buf = Buffer.concat([this.buf, Buffer.alloc(d)]);
+  //   this._pos = newPos;
+  // }
+
+  // get pos(): number {
+  //   return this._pos;
+  // }
+
+  // protected safeRead(position): number {
+  //   return position > this.buf.length ? 0 : this.buf[position];
+  // }
+  // protected safeWrite(position, value): Buffer {
+  //   if (position > this.buf.length) this.buf = Buffer.concat([this.buf, Buffer.alloc(1)]);
+  //   this.buf[position] = value;
+  //   return this.buf;
+  // }
+
+  protected writeString(s: string): void {
+    const len = Buffer.byteLength(s);
+    const buf = this.buf;
+    this.writeLong(len);
+    let pos = this.pos;
+    this.pos += len;
+    if (this.pos > buf.length) {
+      return;
+    }
+    if (len > 64) {
+      // this._writeUtf8(s, len);
+      this.buf.write(s, this.pos - len, len, "utf8");
+    } else {
+      let i, l, c1, c2;
+      for (i = 0, l = len; i < l; i++) {
+        c1 = s.charCodeAt(i);
+        if (c1 < 0x80) {
+          buf[pos++] = c1;
+        } else if (c1 < 0x800) {
+          buf[pos++] = (c1 >> 6) | 0xc0;
+          buf[pos++] = (c1 & 0x3f) | 0x80;
+        } else if ((c1 & 0xfc00) === 0xd800 && ((c2 = s.charCodeAt(i + 1)) & 0xfc00) === 0xdc00) {
+          c1 = 0x10000 + ((c1 & 0x03ff) << 10) + (c2 & 0x03ff);
+          i++;
+          buf[pos++] = (c1 >> 18) | 0xf0;
+          buf[pos++] = ((c1 >> 12) & 0x3f) | 0x80;
+          buf[pos++] = ((c1 >> 6) & 0x3f) | 0x80;
+          buf[pos++] = (c1 & 0x3f) | 0x80;
+        } else {
+          buf[pos++] = (c1 >> 12) | 0xe0;
+          buf[pos++] = ((c1 >> 6) & 0x3f) | 0x80;
+          buf[pos++] = (c1 & 0x3f) | 0x80;
+        }
+      }
+    }
+    this.buf = buf;
+  }
+
+  protected readLong(): number {
     let n = 0;
     let k = 0;
+    const buf = this.buf;
     let b, h, f, fk;
 
     do {
-      b = buf[offset++];
+      b = buf[this.pos++];
       h = b & 0x80;
       n |= (b & 0x7f) << k;
       k += 7;
@@ -68,7 +141,7 @@ export function deserializeTags(bTags: Buffer): { name: string; value: string }[
       f = n;
       fk = 268435456; // 2 ** 28.
       do {
-        b = buf[offset++];
+        b = buf[this.pos++];
         f += (b & 0x7f) * fk;
         fk *= 128;
       } while (b & 0x80);
@@ -76,19 +149,49 @@ export function deserializeTags(bTags: Buffer): { name: string; value: string }[
     }
 
     return (n >> 1) ^ -(n & 1);
-  };
-  // while there are still tags to read...
-  while ((length = decodeLong(bTags)) > 0) {
-    for (let i = 0; i < length; i++) {
-      // decode length
-      const nameLength = decodeLong(bTags);
-      // decode value
-      const name = bTags.slice(offset, (offset += nameLength)).toString();
-      const valueLength = decodeLong(bTags);
-      const value = bTags.slice(offset, (offset += valueLength)).toString();
-      // reconstruct tag object
-      tags.push({ name, value });
-    }
   }
-  return tags;
+
+  protected skipLong(): void {
+    const buf = this.buf;
+    while (buf[this.pos++] & 0x80) {}
+  }
+
+  public readTags(): Tag[] {
+    // var items = this.itemsType;
+    const val = [];
+    let n;
+    while ((n = this.readLong())) {
+      if (n < 0) {
+        n = -n;
+        this.skipLong(); // Skip size.
+      }
+      while (n--) {
+        const name = this.readString();
+        const value = this.readString();
+        val.push(/* items._read(tap) */ { name, value });
+      }
+    }
+    return val;
+  }
+
+  protected readString(): string | undefined {
+    const len = this.readLong();
+    const pos = this.pos;
+    const buf = this.buf;
+    this.pos += len;
+    if (this.pos > buf.length) {
+      return undefined;
+    }
+    return this.buf.slice(pos, pos + len).toString();
+  }
+}
+
+export function serializeTags(tags: Tag[]): Buffer {
+  const tap = new AVSCTap();
+  tap.writeTags(tags);
+  return tap.toBuffer();
+}
+export function deserializeTags(tagsBuffer: Buffer): Tag[] {
+  const tap = new AVSCTap(tagsBuffer);
+  return tap.readTags();
 }


### PR DESCRIPTION
This PR aims to fix a decoding edge case when decoding items encoded using [github.com/hamba/avro](github.com/hamba/avro) (used in [Warp's Syncer](github.com/hamba/avro)) by directly copying the implementation used by AVSC internally, stripped down to only the en/decode procedures we require.
Additionally, this PR establishes a MAX_TAG_BYTES constant.