### PR TITLE
Handle bundles that have data items with empty payloads

### DIFF
--- a/src/__tests__/stream.spec.ts
+++ b/src/__tests__/stream.spec.ts
@@ -6,15 +6,50 @@ import { Readable } from "stream";
 
 const wallet0 = JSON.parse(readFileSync(path.join(__dirname, "test_key0.json")).toString());
 
+const dataItemExpectations = [
+  // Processed bundle stream expectations with id and signature removed as those are non-deterministic
+  {
+    sigName: "arweave",
+    target: "",
+    anchor: "",
+    owner:
+      "wpJ2SmgofIMmxC1UX5d6FPa3LVXbgPZsW5RIhDmYorQjeriATWQkpY9ma2JnDrKCwy1YTao2ADnQjJC0MH6YMrFJg4BV7bFHWaY4RSLF-IVgPjm1GMRSCQnn9tHIBkArrzRWbXS3BRtAj_b719c4-Um9Flq72vv8Z71Nbe3bPA9NTMhYif0XRIKTHgz5t2yz2tYgS6woWMvry2QSwV5SE6kegiUpJSN_u1ulrWHyzULP3tHhanm5qem6F8EiZuraDu6p-OrRZ5pafP4X6d7ErNRZ7Il869aF5THPx65W-3fC3DUo_B57h8R_50LOiyw4dJqb101M_7Y5SjNS0Q1ESQJxbsoOxhmelN6rznkiASNH_mO0bqVqhIy_TvYMWGo7WEPOQDuoob8j4hXLajeH70WZ-Sl6QGOc95bRtNT7F3KqO8uF99Hp3ONGJb5qpnDu7iimPlTYnG1CFHVKVnqzCViIn9viKgsAIrZifjrxE7Zj79lEBwxxsV8KWR3mPIVXnvmHPOe0FXjr056_G5YlCxdIRUxsV4X9GOKmW-GgbHmFOXLO7GV5kI-alEhmIHLH-0MP_Q51MK87VphoiIINc8SlUlOQBXBXLwVCTPerKp9axtdjYHUVLNO2zWONqzbLpAObyQ7Ats0N13S60MwyDVVWcBfyZvjRL2u5hVIGNuU",
+    tags: [],
+    dataOffset: 1204,
+    dataSize: 5,
+  },
+  {
+    sigName: "arweave",
+    target: "",
+    anchor: "",
+    owner:
+      "wpJ2SmgofIMmxC1UX5d6FPa3LVXbgPZsW5RIhDmYorQjeriATWQkpY9ma2JnDrKCwy1YTao2ADnQjJC0MH6YMrFJg4BV7bFHWaY4RSLF-IVgPjm1GMRSCQnn9tHIBkArrzRWbXS3BRtAj_b719c4-Um9Flq72vv8Z71Nbe3bPA9NTMhYif0XRIKTHgz5t2yz2tYgS6woWMvry2QSwV5SE6kegiUpJSN_u1ulrWHyzULP3tHhanm5qem6F8EiZuraDu6p-OrRZ5pafP4X6d7ErNRZ7Il869aF5THPx65W-3fC3DUo_B57h8R_50LOiyw4dJqb101M_7Y5SjNS0Q1ESQJxbsoOxhmelN6rznkiASNH_mO0bqVqhIy_TvYMWGo7WEPOQDuoob8j4hXLajeH70WZ-Sl6QGOc95bRtNT7F3KqO8uF99Hp3ONGJb5qpnDu7iimPlTYnG1CFHVKVnqzCViIn9viKgsAIrZifjrxE7Zj79lEBwxxsV8KWR3mPIVXnvmHPOe0FXjr056_G5YlCxdIRUxsV4X9GOKmW-GgbHmFOXLO7GV5kI-alEhmIHLH-0MP_Q51MK87VphoiIINc8SlUlOQBXBXLwVCTPerKp9axtdjYHUVLNO2zWONqzbLpAObyQ7Ats0N13S60MwyDVVWcBfyZvjRL2u5hVIGNuU",
+    tags: [],
+    dataOffset: 2253,
+    dataSize: 0,
+  },
+];
+
 describe("stream tests", function () {
   it("test", async function () {
     const signer = new ArweaveSigner(wallet0);
-    const item = createData("hello", signer);
-    const bundle = await bundleAndSignData([item], signer);
+    const helloItem = createData("hello", signer);
+    const emptyItem = createData("", signer);
+    const bundle = await bundleAndSignData([helloItem, emptyItem], signer);
 
     const stream = Readable.from(bundle.getRaw());
-    for await (const item of await processStream(stream)) {
-      console.log(item);
+
+    const processedBundleStream = await processStream(stream);
+
+    for (let i = 0; i < processedBundleStream.length; i++) {
+      const dataItem = processedBundleStream[i];
+
+      expect(dataItem.id).toHaveLength(43);
+      expect(dataItem.signature).toHaveLength(683);
+
+      // Remove non-deterministic fields from data item
+      delete dataItem.id, delete dataItem.signature;
+      expect(dataItem).toStrictEqual(dataItemExpectations[i]);
     }
   });
 });

--- a/src/__tests__/stream.spec.ts
+++ b/src/__tests__/stream.spec.ts
@@ -5,15 +5,19 @@ import processStream from "../../src/stream/index";
 import { Readable } from "stream";
 
 const wallet0 = JSON.parse(readFileSync(path.join(__dirname, "test_key0.json")).toString());
+const expectedOwner =
+  "wpJ2SmgofIMmxC1UX5d6FPa3LVXbgPZsW5RIhDmYorQjeriATWQkpY9ma2JnDrKCwy1YTao2ADnQjJC0MH6YMrFJg4BV7bFHWaY4RSLF-IVgPjm1GMRSCQnn9tHIBkArrzRWbXS3BRtAj_b719c4-Um9Flq72vv8Z71Nbe3bPA9NTMhYif0XRIKTHgz5t2yz2tYgS6woWMvry2QSwV5SE6kegiUpJSN_u1ulrWHyzULP3tHhanm5qem6F8EiZuraDu6p-OrRZ5pafP4X6d7ErNRZ7Il869aF5THPx65W-3fC3DUo_B57h8R_50LOiyw4dJqb101M_7Y5SjNS0Q1ESQJxbsoOxhmelN6rznkiASNH_mO0bqVqhIy_TvYMWGo7WEPOQDuoob8j4hXLajeH70WZ-Sl6QGOc95bRtNT7F3KqO8uF99Hp3ONGJb5qpnDu7iimPlTYnG1CFHVKVnqzCViIn9viKgsAIrZifjrxE7Zj79lEBwxxsV8KWR3mPIVXnvmHPOe0FXjr056_G5YlCxdIRUxsV4X9GOKmW-GgbHmFOXLO7GV5kI-alEhmIHLH-0MP_Q51MK87VphoiIINc8SlUlOQBXBXLwVCTPerKp9axtdjYHUVLNO2zWONqzbLpAObyQ7Ats0N13S60MwyDVVWcBfyZvjRL2u5hVIGNuU";
 
+/**
+ * Processed bundle stream expectations with id and signature
+ * removed as those are non-deterministic when using ArweaveSigner
+ */
 const dataItemExpectations = [
-  // Processed bundle stream expectations with id and signature removed as those are non-deterministic
   {
     sigName: "arweave",
     target: "",
     anchor: "",
-    owner:
-      "wpJ2SmgofIMmxC1UX5d6FPa3LVXbgPZsW5RIhDmYorQjeriATWQkpY9ma2JnDrKCwy1YTao2ADnQjJC0MH6YMrFJg4BV7bFHWaY4RSLF-IVgPjm1GMRSCQnn9tHIBkArrzRWbXS3BRtAj_b719c4-Um9Flq72vv8Z71Nbe3bPA9NTMhYif0XRIKTHgz5t2yz2tYgS6woWMvry2QSwV5SE6kegiUpJSN_u1ulrWHyzULP3tHhanm5qem6F8EiZuraDu6p-OrRZ5pafP4X6d7ErNRZ7Il869aF5THPx65W-3fC3DUo_B57h8R_50LOiyw4dJqb101M_7Y5SjNS0Q1ESQJxbsoOxhmelN6rznkiASNH_mO0bqVqhIy_TvYMWGo7WEPOQDuoob8j4hXLajeH70WZ-Sl6QGOc95bRtNT7F3KqO8uF99Hp3ONGJb5qpnDu7iimPlTYnG1CFHVKVnqzCViIn9viKgsAIrZifjrxE7Zj79lEBwxxsV8KWR3mPIVXnvmHPOe0FXjr056_G5YlCxdIRUxsV4X9GOKmW-GgbHmFOXLO7GV5kI-alEhmIHLH-0MP_Q51MK87VphoiIINc8SlUlOQBXBXLwVCTPerKp9axtdjYHUVLNO2zWONqzbLpAObyQ7Ats0N13S60MwyDVVWcBfyZvjRL2u5hVIGNuU",
+    owner: expectedOwner,
     tags: [],
     dataOffset: 1204,
     dataSize: 5,
@@ -22,8 +26,7 @@ const dataItemExpectations = [
     sigName: "arweave",
     target: "",
     anchor: "",
-    owner:
-      "wpJ2SmgofIMmxC1UX5d6FPa3LVXbgPZsW5RIhDmYorQjeriATWQkpY9ma2JnDrKCwy1YTao2ADnQjJC0MH6YMrFJg4BV7bFHWaY4RSLF-IVgPjm1GMRSCQnn9tHIBkArrzRWbXS3BRtAj_b719c4-Um9Flq72vv8Z71Nbe3bPA9NTMhYif0XRIKTHgz5t2yz2tYgS6woWMvry2QSwV5SE6kegiUpJSN_u1ulrWHyzULP3tHhanm5qem6F8EiZuraDu6p-OrRZ5pafP4X6d7ErNRZ7Il869aF5THPx65W-3fC3DUo_B57h8R_50LOiyw4dJqb101M_7Y5SjNS0Q1ESQJxbsoOxhmelN6rznkiASNH_mO0bqVqhIy_TvYMWGo7WEPOQDuoob8j4hXLajeH70WZ-Sl6QGOc95bRtNT7F3KqO8uF99Hp3ONGJb5qpnDu7iimPlTYnG1CFHVKVnqzCViIn9viKgsAIrZifjrxE7Zj79lEBwxxsV8KWR3mPIVXnvmHPOe0FXjr056_G5YlCxdIRUxsV4X9GOKmW-GgbHmFOXLO7GV5kI-alEhmIHLH-0MP_Q51MK87VphoiIINc8SlUlOQBXBXLwVCTPerKp9axtdjYHUVLNO2zWONqzbLpAObyQ7Ats0N13S60MwyDVVWcBfyZvjRL2u5hVIGNuU",
+    owner: expectedOwner,
     tags: [],
     dataOffset: 2253,
     dataSize: 0,
@@ -33,19 +36,21 @@ const dataItemExpectations = [
 describe("stream tests", function () {
   it("test", async function () {
     const signer = new ArweaveSigner(wallet0);
+
     const helloItem = createData("hello", signer);
     const emptyItem = createData("", signer);
+
     const bundle = await bundleAndSignData([helloItem, emptyItem], signer);
 
     const stream = Readable.from(bundle.getRaw());
-
     const processedBundleStream = await processStream(stream);
 
     for (let i = 0; i < processedBundleStream.length; i++) {
       const dataItem = processedBundleStream[i];
 
-      expect(dataItem.id).toHaveLength(43);
-      expect(dataItem.signature).toHaveLength(683);
+      // We expect the processStream function to give us the same id and signature as the bundleAndSignData function
+      expect(dataItem.id).toEqual(bundle.items[i].id);
+      expect(dataItem.signature).toEqual(bundle.items[i].signature);
 
       // Remove non-deterministic fields from data item
       delete dataItem.id, delete dataItem.signature;

--- a/src/stream/index.ts
+++ b/src/stream/index.ts
@@ -181,7 +181,7 @@ export async function streamSigner(s1: Readable, s2: Readable, signer: Signer, o
 }
 
 async function readBytes(reader: AsyncGenerator<Buffer>, buffer: Uint8Array, length: number): Promise<Uint8Array> {
-  if (buffer.byteLength > length) return buffer;
+  if (buffer.byteLength >= length) return buffer;
 
   const { done, value } = await reader.next();
 


### PR DESCRIPTION
This PR adds support for data items with empty payloads on the process stream method. There is increased testing coverage added. I have validated that I am able to unpack bundles from this change:

```sh

~/ar-io/bundle-exporter main !2                        31s node 18.16.0 11:46:01 AM
> node index.js abELEpiWpOZZNFYEwkBKCXWH9JSSs8MxjK8QaY4aknY
Bundle with txId abELEpiWpOZZNFYEwkBKCXWH9JSSs8MxjK8QaY4aknY already exists in ./bundles
Working on bundle with txId abELEpiWpOZZNFYEwkBKCXWH9JSSs8MxjK8QaY4aknY...
Data item count: 2
(1/2) Unpacking data item with txId ECC4MAuSwc0Q4RxA0T9ehviQlWYdfU-kLf_QRYClXcc...
... unpacking item data with size 47 at offset 1236...
(2/2) Unpacking data item with txId UjKLwBe1cdv5iWyj-9h58vEvhIpAxdnB0Y9QLeYq3Qg...
... unpacking item data with size 0 at offset 2327...
Bundles unpacked to ./output folder

~/ar-io/bundle-exporter main !2 ?1                                                             node 18.16.0 11:46:26 AM
> node index.js dJl5lR6vYM-VwnHvWYv_iRP7lJNeGSL3UDTco9tByko
Bundle with txId dJl5lR6vYM-VwnHvWYv_iRP7lJNeGSL3UDTco9tByko already exists in ./bundles
Working on bundle with txId dJl5lR6vYM-VwnHvWYv_iRP7lJNeGSL3UDTco9tByko...
Data item count: 1
(1/1) Unpacking data item with txId RunqhAitvmUyfrJwKxj0t5i7Nl39OU0kGVM0whQHPKM...
... unpacking item data with size 0 at offset 1166...
Bundles unpacked to ./output folder

``` 

These bundles are available to inspect: `dJl5lR6vYM-VwnHvWYv_iRP7lJNeGSL3UDTco9tByko` `abELEpiWpOZZNFYEwkBKCXWH9JSSs8MxjK8QaY4aknY`