### PR TITLE
fix: :bug: exports: Fix missing stream/file node index export

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,3 @@
 export * from "./src/index";
+export * from "./src/stream";
+export * as file from "./src/file";

--- a/src/__tests__/fileBundle.spec.ts
+++ b/src/__tests__/fileBundle.spec.ts
@@ -3,7 +3,7 @@ import { createData } from "../ar-data-create";
 import { FileDataItem } from "../file";
 import type { FileBundle } from "../file/FileBundle";
 import Bundle from "../file/FileBundle";
-import { EthereumSigner } from "../../src/signing";
+import { EthereumSigner } from "../../index";
 import { bundleAndSignData } from "../file";
 import base64url from "base64url";
 import type Transactions from "arweave/node/transactions";

--- a/src/__tests__/stream.spec.ts
+++ b/src/__tests__/stream.spec.ts
@@ -1,6 +1,6 @@
 import { createReadStream, readFileSync, unlinkSync, writeFileSync } from "fs";
 import path from "path";
-import processStream, { streamSigner, streamExportForTesting } from "../../src/stream/index";
+import { processStream, streamSigner, streamExportForTesting } from "../../index";
 import { Readable } from "stream";
 import type { DataItemCreateOptions } from "../../index";
 import { DataItem } from "../../index";

--- a/src/stream/index.ts
+++ b/src/stream/index.ts
@@ -12,7 +12,7 @@ import type { Signer } from "../signing/index";
 import { deserializeTags } from "../tags";
 import { createHash } from "crypto";
 
-export default async function processStream(stream: Readable): Promise<Record<string, any>[]> {
+export async function processStream(stream: Readable): Promise<Record<string, any>[]> {
   const reader = getReader(stream);
   let bytes: Uint8Array = (await reader.next()).value;
   bytes = await readBytes(reader, bytes, 32);
@@ -195,6 +195,8 @@ async function* getReader(s: Readable): AsyncGenerator<Buffer> {
     yield chunk;
   }
 }
+
+export default processStream;
 
 export const streamExportForTesting = {
   readBytes,


### PR DESCRIPTION
This PR fixes missing export statements for the `stream` and `file` components for the NodeJS index.
Additionally, this PR modifies relevant test cases to import from the NodeJS index to prevent further issues.