### PR TITLE
fix: :bug: signers/injectedTypedEthereumSigner: Fix address/pubKey casing

### DIFF
--- a/src/signing/chains/InjectedTypedEthereumSigner.ts
+++ b/src/signing/chains/InjectedTypedEthereumSigner.ts
@@ -10,7 +10,7 @@ export default class InjectedTypedEthereumSigner extends InjectedEthereumSigner 
   private address: string;
 
   async ready(): Promise<void> {
-    this.address = await this.signer.getAddress();
+    this.address = (await this.signer.getAddress()).toLowerCase();
     this.publicKey = Buffer.from(this.address); // pk *is* address
   }
 
@@ -24,8 +24,8 @@ export default class InjectedTypedEthereumSigner extends InjectedEthereumSigner 
   }
 
   static verify(pk: string | Buffer, message: Uint8Array, signature: Uint8Array): boolean {
-    const address = pk;
+    const address = pk.toString();
     const addr = verifyTypedData(domain, types, { address, "Transaction hash": message }, signature);
-    return address === addr;
+    return address.toLowerCase() === addr.toLowerCase();
   }
 }


### PR DESCRIPTION
This PR "fixes" the internal Ethereum address (pubkey for this signer) casing to be the consistent (and eth equivalent) lowercase to match the case expectations for the rest of the API