### PR TITLE
fix: :bug: signers/arconnect: Fix arconnect signer using a saltLength of 0

### DIFF
--- a/src/signing/chains/arconnectSigner.ts
+++ b/src/signing/chains/arconnectSigner.ts
@@ -28,7 +28,7 @@ export default class InjectedArweaveSigner implements Signer {
 
     const algorithm = {
       name: "RSA-PSS",
-      saltLength: 0,
+      saltLength: 32,
     };
 
     const signature = await this.signer.signature(message, algorithm);


### PR DESCRIPTION
This PR fixes #75 by changing saltLength from 0 to the recommended 32.